### PR TITLE
Add asyncio trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Environment :: MacOS X',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Internet',
+        'Framework :: AsyncIO',
     ],
     author='Samuel Colvin',
     author_email='s@muelcolvin.com',


### PR DESCRIPTION
The `Framework :: AsyncIO` [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) has recently been added to PyPI. It can help people discover asyncio related packages.