### PR TITLE
Fix string substitution typo in logging.

### DIFF
--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -46,7 +46,7 @@ def modify_main_app(app, config: Config):
                     'text/html' in response.content_type and
                     getattr(response, 'body', False)):
                 lr_snippet = LIVE_RELOAD_HOST_SNIPPET.format(get_host(request), config.aux_port)
-                dft_logger.debug('appending live reload snippet "%" to body', lr_snippet)
+                dft_logger.debug('appending live reload snippet "%s" to body', lr_snippet)
                 response.body += lr_snippet.encode()
         app.on_response_prepare.append(on_prepare)
 


### PR DESCRIPTION
This fixes an issue where an exception raised in my own code causes an empty response instead of an error page with the stacktrace. In the console, it reported `ValueError: unsupported format character '"' (0x22) at index 32`.