### PR TITLE
improved loop handling

### DIFF
--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -32,11 +32,10 @@ def run_app(app, port, loop):
             loop.close()
 
 
-def runserver(*, loop: asyncio.AbstractEventLoop=None, **config_kwargs):
+def runserver(**config_kwargs):
     """
     Prepare app ready to run development server.
 
-    :param loop: asyncio loop to use
     :param config_kwargs: see config.Config for more details
     :return: tuple (auxiliary app, auxiliary app port, event loop)
     """
@@ -44,8 +43,8 @@ def runserver(*, loop: asyncio.AbstractEventLoop=None, **config_kwargs):
     set_start_method('spawn')
 
     config = Config(**config_kwargs)
-    loop = loop or asyncio.get_event_loop()
-    config.check(loop)
+    config.check()
+    loop = asyncio.get_event_loop()
 
     loop.run_until_complete(check_port_open(config.main_port, loop))
 
@@ -75,11 +74,10 @@ def runserver(*, loop: asyncio.AbstractEventLoop=None, **config_kwargs):
     return aux_app, config.aux_port, loop
 
 
-def serve_static(*, static_path: str, livereload: bool=True, port: int=8000,
-                 loop: asyncio.AbstractEventLoop=None):
+def serve_static(*, static_path: str, livereload: bool=True, port: int=8000):
     logger.debug('Config: path="%s", livereload=%s, port=%s', static_path, livereload, port)
 
-    loop = loop or asyncio.get_event_loop()
+    loop = asyncio.get_event_loop()
     app = create_auxiliary_app(static_path=static_path, livereload=livereload)
 
     if livereload:

--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -105,13 +105,13 @@ def set_tty(tty_path):  # pragma: no cover
         yield
 
 
-def serve_main_app(config: Config, tty_path: Optional[str], loop: asyncio.AbstractEventLoop=None):
+def serve_main_app(config: Config, tty_path: Optional[str]):
     with set_tty(tty_path):
         setup_logging(config.verbose)
 
-        loop = loop or asyncio.get_event_loop()
+        app = config.load_app()
 
-        app = config.load_app(loop)
+        loop = asyncio.get_event_loop()
 
         modify_main_app(app, config)
 

--- a/aiohttp_devtools/start/template/app/main.py
+++ b/aiohttp_devtools/start/template/app/main.py
@@ -124,7 +124,7 @@ def setup_routes(app):
     # {% endif %}
 
 
-def create_app(loop):
+def create_app():
     app = web.Application()
     settings = Settings()
     app.update(

--- a/aiohttp_devtools/version.py
+++ b/aiohttp_devtools/version.py
@@ -2,4 +2,4 @@ from distutils.version import StrictVersion
 
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('0.6.3')
+VERSION = StrictVersion('0.6.4')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from aiohttp import web
 async def hello(request):
     return web.Response(text='hello world')
 
-def create_app(loop):
+def create_app():
     app = web.Application()
     app.router.add_get('/', hello)
     return app"""

--- a/tests/test_runserver_config.py
+++ b/tests/test_runserver_config.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from pytest_toolbox import mktree
 
@@ -16,8 +18,9 @@ async def test_load_simple_app(tmpworkdir):
 
 async def test_create_app_wrong_name(tmpworkdir, loop):
     mktree(tmpworkdir, SIMPLE_APP)
+    config = Config(app_path='app.py', app_factory_name='missing')
     with pytest.raises(AiohttpDevConfigError) as excinfo:
-        Config(app_path='app.py', app_factory_name='missing')
+        config.import_app_factory()
     assert excinfo.value.args[0] == 'Module "app.py" does not define a "missing" attribute/class'
 
 
@@ -56,7 +59,8 @@ def app_factory(loop):
 @if_boxed
 @pytest.mark.parametrize('files,exc', invalid_apps, ids=['%s...' % v[1][:40] for v in invalid_apps])
 def test_invalid_options(tmpworkdir, files, exc, loop):
+    asyncio.set_event_loop(loop)
     mktree(tmpworkdir, files)
     with pytest.raises(AiohttpDevConfigError) as excinfo:
-        Config(app_path='.').check(loop)
+        Config(app_path='.').check()
     assert exc.format(tmpworkdir=tmpworkdir) == excinfo.value.args[0]

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from pytest_toolbox import mktree
 
@@ -6,7 +8,8 @@ from aiohttp_devtools.runserver import serve_static
 
 @pytest.yield_fixture
 def cli(loop, tmpworkdir, test_client):
-    app, _, _ = serve_static(static_path=str(tmpworkdir), livereload=False, loop=loop)
+    asyncio.set_event_loop(loop)
+    app, _, _ = serve_static(static_path=str(tmpworkdir), livereload=False)
     yield loop.run_until_complete(test_client(app))
 
 
@@ -29,7 +32,7 @@ async def test_file_missing(cli):
 
 
 async def test_html_file_livereload(loop, test_client, tmpworkdir):
-    app, port, _ = serve_static(static_path=str(tmpworkdir), livereload=True, loop=loop)
+    app, port, _ = serve_static(static_path=str(tmpworkdir), livereload=True)
     assert port == 8000
     cli = await test_client(app)
     mktree(tmpworkdir, {
@@ -48,7 +51,7 @@ async def test_html_file_livereload(loop, test_client, tmpworkdir):
 
 
 async def test_serve_index(loop, test_client, tmpworkdir):
-    app, port, _ = serve_static(static_path=str(tmpworkdir), livereload=False, loop=loop)
+    app, port, _ = serve_static(static_path=str(tmpworkdir), livereload=False)
     assert port == 8000
     cli = await test_client(app)
     mktree(tmpworkdir, {

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -64,7 +64,8 @@ adev.main INFO: config:
     example: message-board
 adev.main INFO: project created, 16 files generated\n""" == caplog.log.replace(str(tmpdir), '/<tmpdir>')
     config = Config(app_path='the-path/app/', root_path=str(tmpdir))
-    app = config.app_factory(loop=loop)
+    app_factory = config.import_app_factory()
+    app = app_factory()
     modify_main_app(app, config)
     assert isinstance(app, aiohttp.web.Application)
 
@@ -109,7 +110,8 @@ async def test_all_options(tmpdir, test_client, loop, template_engine, session, 
         return
     config = Config(app_path='app/main.py', root_path=str(tmpdir))
 
-    app = config.app_factory(loop=loop)
+    app_factory = config.import_app_factory()
+    app = app_factory()
     modify_main_app(app, config)
     cli = await test_client(app)
     r = await cli.get('/')
@@ -147,7 +149,8 @@ async def test_db_creation(tmpdir, test_client, loop):
     os.environ['APP_DB_PASSWORD'] = db_password
     config = Config(app_path='app/main.py', root_path=str(tmpdir))
 
-    app = config.app_factory(loop=loop)
+    app_factory = config.import_app_factory()
+    app = app_factory()
     modify_main_app(app, config)
     cli = await test_client(app)
     r = await cli.get('/')


### PR DESCRIPTION
fixes #156
replaces #157

This package passed loops around a lot, this was mainly required for tests to pass with python < 3.5.2 where `set_event_loop` didn't work properly.

This in turn was causing problems with uvloop, either meaning the wrong loop was used or a "different loop" error occurred.

The fixes here can be demonstrated by the micro example 

```py
from aiohttp import web
import asyncio
import uvloop

async def handle(request):
    return web.Response(text=f'loop: {request.app.loop}')

asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
app = web.Application()
app.router.add_get('/', handle)
```

Run with

    adev runserver demo.py

Should now return `loop: <uvloop.Loop running=True closed=False debug=False>` while before it was using the standard python loop.

@vladiibine would be great if you could try this and confirm it works for you.