### PR TITLE
when not serving static files, don't mess the apps static_root_url

### DIFF
--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -54,22 +54,21 @@ def modify_main_app(app, config: Config):
         app.on_response_prepare.append(on_prepare)
 
     static_path = config.static_url.strip('/')
-    # we set the app key even in middleware to make the switch to production easier and for backwards compat.
-    if config.infer_host:
-        async def static_middleware(app, handler):
-
-            async def _handler(request):
-                static_url = 'http://{}:{}/{}'.format(get_host(request), config.aux_port, static_path)
-                dft_logger.debug('settings app static_root_url to "%s"', static_url)
-                app['static_root_url'] = static_url
-                return await handler(request)
-            return _handler
+    if config.infer_host and config.static_path is not None:
+        # we set the app key even in middleware to make the switch to production easier and for backwards compat.
+        @web.middleware
+        async def static_middleware(request, handler):
+            static_url = 'http://{}:{}/{}'.format(get_host(request), config.aux_port, static_path)
+            dft_logger.debug('settings app static_root_url to "%s"', static_url)
+            request.app['static_root_url'] = static_url
+            return await handler(request)
 
         app.middlewares.insert(0, static_middleware)
 
-    static_url = 'http://{}:{}/{}'.format(config.host, config.aux_port, static_path)
-    dft_logger.debug('settings app static_root_url to "%s"', static_url)
-    app['static_root_url'] = static_url
+    if config.static_path is not None:
+        static_url = 'http://{}:{}/{}'.format(config.host, config.aux_port, static_path)
+        dft_logger.debug('settings app static_root_url to "%s"', static_url)
+        app['static_root_url'] = static_url
 
     if config.debug_toolbar:
         aiohttp_debugtoolbar.setup(app, intercept_redirects=False)

--- a/tests/test_runserver_serve.py
+++ b/tests/test_runserver_serve.py
@@ -117,11 +117,12 @@ class DummyApplication(dict):
         self.on_response_prepare = []
         self.middlewares = []
         self.router = MagicMock()
+        self['static_root_url'] = '/static/'
 
 
 def test_modify_main_app_all_off(tmpworkdir):
     mktree(tmpworkdir, SIMPLE_APP)
-    config = Config(app_path='app.py', livereload=False, host='foobar.com')
+    config = Config(app_path='app.py', livereload=False, host='foobar.com', static_path='.')
     app = DummyApplication()
     modify_main_app(app, config)
     assert len(app.on_response_prepare) == 0
@@ -132,7 +133,7 @@ def test_modify_main_app_all_off(tmpworkdir):
 
 def test_modify_main_app_all_on(tmpworkdir):
     mktree(tmpworkdir, SIMPLE_APP)
-    config = Config(app_path='app.py', debug_toolbar=True)
+    config = Config(app_path='app.py', debug_toolbar=True, static_path='.')
     app = DummyApplication()
     modify_main_app(app, config)
     assert len(app.on_response_prepare) == 1

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -63,7 +63,7 @@ adev.main INFO: config:
     database: none
     example: message-board
 adev.main INFO: project created, 16 files generated\n""" == caplog.log.replace(str(tmpdir), '/<tmpdir>')
-    config = Config(app_path='the-path/app/', root_path=str(tmpdir))
+    config = Config(app_path='the-path/app/', root_path=str(tmpdir), static_path='.')
     app_factory = config.import_app_factory()
     app = app_factory()
     modify_main_app(app, config)
@@ -108,7 +108,7 @@ async def test_all_options(tmpdir, test_client, loop, template_engine, session, 
     assert report.total_errors == 0
     if database != 'none':
         return
-    config = Config(app_path='app/main.py', root_path=str(tmpdir))
+    config = Config(app_path='app/main.py', root_path=str(tmpdir), static_path='.')
 
     app_factory = config.import_app_factory()
     app = app_factory()
@@ -147,7 +147,7 @@ async def test_db_creation(tmpdir, test_client, loop):
     assert 'creating tables from model definition...'
 
     os.environ['APP_DB_PASSWORD'] = db_password
-    config = Config(app_path='app/main.py', root_path=str(tmpdir))
+    config = Config(app_path='app/main.py', root_path=str(tmpdir), static_path='.')
 
     app_factory = config.import_app_factory()
     app = app_factory()


### PR DESCRIPTION
I am serving the static files from within my app. the app's static_root_url get's messed up even, if I don't use --static on adev cli.
Added two ifs to only modify the app's static_root_url when the aux server is actually serving files

NB: I didn't get, why this three lines are there twice, from first look, outer should be sufficient?