### PR TITLE
Add CORS headers to fix issue with webfonts

### DIFF
--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -349,6 +349,9 @@ class CustomStaticResource(StaticResource):
             response = web.Response(body=_404_msg.encode(), status=404, content_type='text/plain')
             status, length = response.status, response.content_length
         else:
+            # Inject CORS headers to allow webfonts to load correctly
+            response.headers['Access-Control-Allow-Origin'] = '*'
+
             status, length = response.status, response.content_length
         finally:
             logger = aux_logger.info if status in {200, 304} else aux_logger.warning

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -20,6 +20,7 @@ async def test_simple_serve(cli, tmpworkdir):
     r = await cli.get('/foo')
     assert r.status == 200
     assert r.headers['content-type'] == 'application/octet-stream'
+    assert r.headers['Access-Control-Allow-Origin'] == '*'
     text = await r.text()
     assert text == 'hello world'
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -20,7 +20,7 @@ async def test_simple_serve(cli, tmpworkdir):
     r = await cli.get('/foo')
     assert r.status == 200
     assert r.headers['content-type'] == 'application/octet-stream'
-    assert r.headers['Access-Control-Allow-Origin'] == '*'
+    assert 'Access-Control-Allow-Origin' in r.headers and r.headers['Access-Control-Allow-Origin'] == '*'
     text = await r.text()
     assert text == 'hello world'
 


### PR DESCRIPTION
For web browser to be able to load and apply webfonts to web page correctly from different domain, we need to add these Cross-origin Resource Sharing headers to static files served from devtools