### PR TITLE
Compatibility with Windows for model_path assigning in config.py

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+0.10.2 (2018-06-09)
+-------------------
+* fix path defining to work both for Unix and Windows
+
 0.10.1 (2018-06-06)
 -------------------
 * fix logging with ``runserver`` #193

--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -123,7 +123,7 @@ class Config:
         :return: (attribute, Path object for directory of file)
         """
         rel_py_file = self.py_file.relative_to(self.python_path)
-        module_path = '.'.join(rel_py_file.parts).rstrip('.py')
+        module_path = '.'.join(rel_py_file.with_suffix('').parts)
 
         sys.path.append(str(self.python_path))
         try:

--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -123,7 +123,7 @@ class Config:
         :return: (attribute, Path object for directory of file)
         """
         rel_py_file = self.py_file.relative_to(self.python_path)
-        module_path = str(rel_py_file).replace('.py', '').replace('/', '.').replace('\\', '.')
+        module_path = '.'.join(rel_py_file.parts).rstrip('.py')
 
         sys.path.append(str(self.python_path))
         try:

--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -123,7 +123,7 @@ class Config:
         :return: (attribute, Path object for directory of file)
         """
         rel_py_file = self.py_file.relative_to(self.python_path)
-        module_path = str(rel_py_file).replace('.py', '').replace('/', '.')
+        module_path = str(rel_py_file).replace('.py', '').replace('/', '.').replace('\\', '.')
 
         sys.path.append(str(self.python_path))
         try:


### PR DESCRIPTION
Added a small fix to model_path variable assigning in config.py / import_app_factory def.
This should make life of Python programmers on Windows a bit easier ( I've caught myself an issue similar to described here: https://github.com/aio-libs/aiohttp-devtools/issues/179 ).

Thanks a lot for the awesome aiohttp development tools library :)