### PR TITLE
Handle signals when running app.

### DIFF
--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -13,7 +13,7 @@ from .watch import AppTask, LiveReloadTask
 
 
 def run_app(app, port, loop, access_log_class):
-    runner = AppRunner(app, access_log_class=access_log_class)
+    runner = AppRunner(app, handle_signals=True, access_log_class=access_log_class)
     loop.run_until_complete(runner.setup())
 
     site = TCPSite(runner, HOST, port, shutdown_timeout=0.01)

--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -3,7 +3,7 @@ import contextlib
 import os
 from multiprocessing import set_start_method
 
-from aiohttp.web_runner import AppRunner, TCPSite
+from aiohttp.web_runner import AppRunner, GracefulExit, TCPSite
 
 from ..logs import rs_dft_logger as logger
 from .config import Config
@@ -21,7 +21,7 @@ def run_app(app, port, loop, access_log_class):
 
     try:
         loop.run_forever()
-    except KeyboardInterrupt:  # pragma: no branch
+    except (GracefulExit, KeyboardInterrupt):  # pragma: no branch
         pass
     finally:
         logger.info('shutting down server...')


### PR DESCRIPTION
Edit:
It appears that the run_app() function does the same thing as aiohttp's run_app() function (maybe copied from it in the past?). So, rather than this PR, I'm proposing an alternative #265 to remove this function and use aiohttp's, which solves this bug, and possibly other unknown or future bugs.

Unless I'm missing some reason for the custom run_app() function, that I couldn't see, please merge #265 and reject this PR.

--------------------------------

Fixes #252 

Atleast when I use runserver (through LXC), Ctrl+C tries to kill the process, but the application does not get killed properly, the cleanup context does not run, and the process is left hanging in a semi-running state with no way for me to stop it other than killing lxc.

This seems to fix this issue, by having the AppRunner handle the SIGTERM/SIGINT and exiting cleanly.