### PR TITLE
Fix cleanup not running when exception occurs in startup.

### DIFF
--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -155,7 +155,8 @@ async def test_serve_main_app(tmpworkdir, loop, mocker):
     loop.call_later(0.5, loop.stop)
 
     config = Config(app_path='app.py')
-    await start_main_app(config, config.import_app_factory(), loop)
+    runner = await create_main_app(config, config.import_app_factory(), loop)
+    await start_main_app(runner, config.main_port)
 
     mock_modify_main_app.assert_called_with(mock.ANY, config)
 
@@ -176,7 +177,8 @@ app.router.add_get('/', hello)
     mock_modify_main_app = mocker.patch('aiohttp_devtools.runserver.serve.modify_main_app')
 
     config = Config(app_path='app.py')
-    await start_main_app(config, config.import_app_factory(), loop)
+    runner = await create_main_app(config, config.import_app_factory(), loop)
+    await start_main_app(runner, config.main_port)
 
     mock_modify_main_app.assert_called_with(mock.ANY, config)
 

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -15,7 +15,8 @@ from pytest_toolbox import mktree
 
 from aiohttp_devtools.runserver import run_app, runserver
 from aiohttp_devtools.runserver.config import Config
-from aiohttp_devtools.runserver.serve import create_auxiliary_app, create_main_app, modify_main_app, src_reload, start_main_app
+from aiohttp_devtools.runserver.serve import (create_auxiliary_app, create_main_app, modify_main_app, src_reload,
+                                              start_main_app)
 
 from .conftest import SIMPLE_APP
 

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -15,7 +15,7 @@ from pytest_toolbox import mktree
 
 from aiohttp_devtools.runserver import run_app, runserver
 from aiohttp_devtools.runserver.config import Config
-from aiohttp_devtools.runserver.serve import create_auxiliary_app, modify_main_app, src_reload, start_main_app
+from aiohttp_devtools.runserver.serve import create_auxiliary_app, create_main_app, modify_main_app, src_reload, start_main_app
 
 from .conftest import SIMPLE_APP
 


### PR DESCRIPTION
In addition to my previous fix, I've found that cleanup is not running, if an exception occurs during any of the startup tasks.

This helps fix this. However, there is an additional fix needed in aiohttp before it fully works.