### PR TITLE
Remove ImportError catching.

### DIFF
--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -130,11 +130,7 @@ class Config:
         module_path = '.'.join(rel_py_file.with_suffix('').parts)
 
         sys.path.append(str(self.python_path))
-        try:
-            module = import_module(module_path)
-        except ImportError as e:
-            raise AdevConfigError('error importing "{}" '
-                                  'from "{}": {}'.format(module_path, self.python_path, e)) from e
+        module = import_module(module_path)
 
         logger.debug('successfully loaded "%s" from "%s"', module_path, self.python_path)
 


### PR DESCRIPTION
I'd like to suggest removing this ImportError catch. It's caught me out a couple of times already.

All it seems to achieve is hiding where the error is. When I have an error during import, I get a short message with no traceback, so I have no idea what file or line number the error is in. While there is a `-v` option to show the traceback, it doesn't appear in the documentation and I wouldn't expect a user to think about using the option when an exception at any other point in the application shows the exception normally.

The current message isn't even clear that it's an exception. What I see is:
`Error: error importing "module.app" from "[module_path]": No module named 'wrong_name'`