### PR TITLE
Fix static URL for subapps.

### DIFF
--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -49,6 +49,16 @@ def modify_main_app(app, config: Config):
         else:
             return config.host
 
+    def set_static_url(app, url):
+        app['static_root_url'] = MutableValue(url)
+        for subapp in app._subapps:
+            set_static_url(subapp, url)
+
+    def change_static_url(app, url):
+        app['static_root_url'].change(url)
+        for subapp in app._subapps:
+            set_static_url(subapp, url)
+
     if config.livereload:
         async def on_prepare(request, response):
             if (not request.path.startswith('/_debugtoolbar') and
@@ -66,11 +76,7 @@ def modify_main_app(app, config: Config):
         async def static_middleware(request, handler):
             static_url = 'http://{}:{}/{}'.format(get_host(request), config.aux_port, static_path)
             dft_logger.debug('setting app static_root_url to "%s"', static_url)
-            def set_static_url(app, url):
-                app['static_root_url'].change(url)
-                for subapp in app._subapps:
-                    set_static_url(subapp, url)
-            set_static_url(request.app, static_url)
+            change_static_url(request.app, static_url)
             return await handler(request)
 
         app.middlewares.insert(0, static_middleware)
@@ -78,10 +84,6 @@ def modify_main_app(app, config: Config):
     if config.static_path is not None:
         static_url = 'http://{}:{}/{}'.format(config.host, config.aux_port, static_path)
         dft_logger.debug('settings app static_root_url to "%s"', static_url)
-        def set_static_url(app, url):
-            app['static_root_url'] = MutableValue(url)
-            for subapp in app._subapps:
-                set_static_url(subapp, url)
         set_static_url(app, static_url)
 
     if config.debug_toolbar and aiohttp_debugtoolbar:

--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -57,7 +57,7 @@ def modify_main_app(app, config: Config):
     def change_static_url(app, url):
         app['static_root_url'].change(url)
         for subapp in app._subapps:
-            set_static_url(subapp, url)
+            change_static_url(subapp, url)
 
     if config.livereload:
         async def on_prepare(request, response):

--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -36,13 +36,13 @@ HOST = '0.0.0.0'
 def _set_static_url(app, url):
     app['static_root_url'] = MutableValue(url)
     for subapp in app._subapps:
-        set_static_url(subapp, url)
+        _set_static_url(subapp, url)
 
-        
+
 def _change_static_url(app, url):
     app['static_root_url'].change(url)
     for subapp in app._subapps:
-        change_static_url(subapp, url)
+        _change_static_url(subapp, url)
 
 
 def modify_main_app(app, config: Config):

--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -34,13 +34,13 @@ HOST = '0.0.0.0'
 
 
 def _set_static_url(app, url):
-    app['static_root_url'] = MutableValue(url)
+    app["static_root_url"] = MutableValue(url)
     for subapp in app._subapps:
         _set_static_url(subapp, url)
 
 
 def _change_static_url(app, url):
-    app['static_root_url'].change(url)
+    app["static_root_url"].change(url)
     for subapp in app._subapps:
         _change_static_url(subapp, url)
 

--- a/tests/test_runserver_serve.py
+++ b/tests/test_runserver_serve.py
@@ -143,12 +143,12 @@ def test_modify_main_app_all_off(tmpworkdir):
     config = Config(app_path='app.py', livereload=False, host='foobar.com', static_path='.')
     app = DummyApplication()
     subapp = DummyApplication()
-    app.add_subapp('/sub/', subapp)
+    app.add_subapp("/sub/", subapp)
     modify_main_app(app, config)
     assert len(app.on_response_prepare) == 0
     assert len(app.middlewares) == 0
     assert app['static_root_url'] == 'http://foobar.com:8001/static'
-    assert subapp['static_root_url'] == 'http://foobar.com:8001/static'
+    assert subapp["static_root_url"] == "http://foobar.com:8001/static"
     assert app._debug is True
 
 
@@ -157,12 +157,12 @@ def test_modify_main_app_all_on(tmpworkdir):
     config = Config(app_path='app.py', debug_toolbar=True, static_path='.')
     app = DummyApplication()
     subapp = DummyApplication()
-    app.add_subapp('/sub/', subapp)
+    app.add_subapp("/sub/", subapp)
     modify_main_app(app, config)
     assert len(app.on_response_prepare) == 1
     assert len(app.middlewares) == 2
     assert app['static_root_url'] == 'http://localhost:8001/static'
-    assert subapp['static_root_url'] == 'http://localhost:8001/static'
+    assert subapp['static_root_url'] == "http://localhost:8001/static"
     assert app._debug is True
 
 

--- a/tests/test_runserver_serve.py
+++ b/tests/test_runserver_serve.py
@@ -138,10 +138,13 @@ def test_modify_main_app_all_off(tmpworkdir):
     mktree(tmpworkdir, SIMPLE_APP)
     config = Config(app_path='app.py', livereload=False, host='foobar.com', static_path='.')
     app = DummyApplication()
+    subapp = DummyApplication()
+    app.add_subapp('/sub/', subapp)
     modify_main_app(app, config)
     assert len(app.on_response_prepare) == 0
     assert len(app.middlewares) == 0
     assert app['static_root_url'] == 'http://foobar.com:8001/static'
+    assert subapp['static_root_url'] == 'http://foobar.com:8001/static'
     assert app._debug is True
 
 
@@ -149,10 +152,13 @@ def test_modify_main_app_all_on(tmpworkdir):
     mktree(tmpworkdir, SIMPLE_APP)
     config = Config(app_path='app.py', debug_toolbar=True, static_path='.')
     app = DummyApplication()
+    subapp = DummyApplication()
+    app.add_subapp('/sub/', subapp)
     modify_main_app(app, config)
     assert len(app.on_response_prepare) == 1
     assert len(app.middlewares) == 2
     assert app['static_root_url'] == 'http://localhost:8001/static'
+    assert subapp['static_root_url'] == 'http://localhost:8001/static'
     assert app._debug is True
 
 

--- a/tests/test_runserver_serve.py
+++ b/tests/test_runserver_serve.py
@@ -133,8 +133,8 @@ class DummyApplication(dict):
         self.router = MagicMock()
         self['static_root_url'] = '/static/'
         self._subapps = []
-        
-    def add_subapp(self, app):
+
+    def add_subapp(self, path, app):
         self._subapps.append(app)
 
 

--- a/tests/test_runserver_serve.py
+++ b/tests/test_runserver_serve.py
@@ -132,6 +132,10 @@ class DummyApplication(dict):
         self.middlewares = []
         self.router = MagicMock()
         self['static_root_url'] = '/static/'
+        self._subapps = []
+        
+    def add_subapp(self, app):
+        self._subapps.append(app)
 
 
 def test_modify_main_app_all_off(tmpworkdir):


### PR DESCRIPTION
The static URL doesn't get set correctly in subapps. aiohttp doesn't seem to expose the subapps with a public attribute, so this is the best solution I can see.