### PR TITLE
Fix deprecation warnings

### DIFF
--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -86,4 +86,4 @@ def serve_static(*, static_path: str, livereload: bool = True, port: int = 8000)
 
     livereload_status = 'ON' if livereload else 'OFF'
     logger.info('Serving "%s" at http://localhost:%d, livereload %s', static_path, port, livereload_status)
-    return app, port, loop, AuxAccessLogger
+    return app, port, AuxAccessLogger

--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -53,12 +53,12 @@ def runserver(**config_kwargs):
         livereload=config.livereload,
     )
 
-    main_manager = AppTask(config, loop)
+    main_manager = AppTask(config)
     aux_app.on_startup.append(main_manager.start)
     aux_app.on_shutdown.append(main_manager.close)
 
     if config.static_path:
-        static_manager = LiveReloadTask(config.static_path, loop)
+        static_manager = LiveReloadTask(config.static_path)
         logger.debug('starting livereload to watch %s', config.static_path_str)
         aux_app.on_startup.append(static_manager.start)
         aux_app.on_shutdown.append(static_manager.close)
@@ -76,11 +76,10 @@ def runserver(**config_kwargs):
 def serve_static(*, static_path: str, livereload: bool = True, port: int = 8000):
     logger.debug('Config: path="%s", livereload=%s, port=%s', static_path, livereload, port)
 
-    loop = asyncio.get_event_loop()
     app = create_auxiliary_app(static_path=static_path, livereload=livereload)
 
     if livereload:
-        livereload_manager = LiveReloadTask(static_path, loop)
+        livereload_manager = LiveReloadTask(static_path)
         logger.debug('starting livereload to watch %s', static_path)
         app.on_startup.append(livereload_manager.start)
         app.on_shutdown.append(livereload_manager.close)

--- a/aiohttp_devtools/runserver/watch.py
+++ b/aiohttp_devtools/runserver/watch.py
@@ -23,7 +23,7 @@ class WatchTask:
 
     async def start(self, app):
         self._app = app
-        self._task = asyncio.get_running_loop().create_task(self._run())
+        self._task = asyncio.get_event_loop().create_task(self._run())
 
     async def _run(self):
         raise NotImplementedError()

--- a/aiohttp_devtools/runserver/watch.py
+++ b/aiohttp_devtools/runserver/watch.py
@@ -14,17 +14,16 @@ from .serve import WS, serve_main_app, src_reload
 
 
 class WatchTask:
-    def __init__(self, path: str, loop: asyncio.AbstractEventLoop):
-        self._loop = loop
+    def __init__(self, path: str):
         self._app = None
         self._task = None
         assert path
-        self.stopper = asyncio.Event(loop=self._loop)
+        self.stopper = asyncio.Event()
         self._awatch = awatch(path, stop_event=self.stopper)
 
     async def start(self, app):
         self._app = app
-        self._task = self._loop.create_task(self._run())
+        self._task = asyncio.create_task(self._run())
 
     async def _run(self):
         raise NotImplementedError()
@@ -41,12 +40,12 @@ class WatchTask:
 class AppTask(WatchTask):
     template_files = '.html', '.jinja', '.jinja2'
 
-    def __init__(self, config: Config, loop: asyncio.AbstractEventLoop):
+    def __init__(self, config: Config):
         self._config = config
         self._reloads = 0
         self._session = None
         self._runner = None
-        super().__init__(self._config.watch_path, loop)
+        super().__init__(self._config.watch_path)
 
     async def _run(self, live_checks=20):
         self._session = ClientSession()

--- a/aiohttp_devtools/runserver/watch.py
+++ b/aiohttp_devtools/runserver/watch.py
@@ -23,7 +23,7 @@ class WatchTask:
 
     async def start(self, app):
         self._app = app
-        self._task = asyncio.create_task(self._run())
+        self._task = asyncio.get_running_loop().create_task(self._run())
 
     async def _run(self):
         raise NotImplementedError()

--- a/tests/test_runserver_watch.py
+++ b/tests/test_runserver_watch.py
@@ -144,6 +144,7 @@ class FakeProcess:
 def test_stop_process_dead(smart_caplog, mocker):
     mock_kill = mocker.patch('aiohttp_devtools.runserver.watch.os.kill')
     mocker.patch('aiohttp_devtools.runserver.watch.awatch')
+    mocker.patch('asyncio.Event')
     app_task = AppTask(MagicMock())
     app_task._process = MagicMock()
     app_task._process.is_alive = MagicMock(return_value=False)
@@ -156,6 +157,7 @@ def test_stop_process_dead(smart_caplog, mocker):
 def test_stop_process_clean(mocker):
     mock_kill = mocker.patch('aiohttp_devtools.runserver.watch.os.kill')
     mocker.patch('aiohttp_devtools.runserver.watch.awatch')
+    mocker.patch('asyncio.Event')
     app_task = AppTask(MagicMock())
     app_task._process = MagicMock()
     app_task._process.is_alive = MagicMock(return_value=True)

--- a/tests/test_runserver_watch.py
+++ b/tests/test_runserver_watch.py
@@ -144,7 +144,7 @@ class FakeProcess:
 def test_stop_process_dead(smart_caplog, mocker):
     mock_kill = mocker.patch('aiohttp_devtools.runserver.watch.os.kill')
     mocker.patch('aiohttp_devtools.runserver.watch.awatch')
-    app_task = AppTask(MagicMock(), MagicMock())
+    app_task = AppTask(MagicMock())
     app_task._process = MagicMock()
     app_task._process.is_alive = MagicMock(return_value=False)
     app_task._process.exitcode = 123
@@ -156,7 +156,7 @@ def test_stop_process_dead(smart_caplog, mocker):
 def test_stop_process_clean(mocker):
     mock_kill = mocker.patch('aiohttp_devtools.runserver.watch.os.kill')
     mocker.patch('aiohttp_devtools.runserver.watch.awatch')
-    app_task = AppTask(MagicMock(), MagicMock())
+    app_task = AppTask(MagicMock())
     app_task._process = MagicMock()
     app_task._process.is_alive = MagicMock(return_value=True)
     app_task._process.pid = 321
@@ -169,7 +169,7 @@ def test_stop_process_clean(mocker):
 def test_stop_process_dirty(mocker):
     mock_kill = mocker.patch('aiohttp_devtools.runserver.watch.os.kill')
     mocker.patch('aiohttp_devtools.runserver.watch.awatch')
-    app_task = AppTask(MagicMock(), MagicMock())
+    app_task = AppTask(MagicMock())
     app_task._process = MagicMock()
     app_task._process.is_alive = MagicMock(return_value=True)
     app_task._process.pid = 321

--- a/tests/test_runserver_watch.py
+++ b/tests/test_runserver_watch.py
@@ -39,7 +39,7 @@ async def test_single_file_change(loop, mocker):
     mocked_awatch.side_effect = create_awatch_mock()
     mock_src_reload = mocker.patch('aiohttp_devtools.runserver.watch.src_reload', return_value=create_future())
 
-    app_task = AppTask(MagicMock(), loop)
+    app_task = AppTask(MagicMock())
     app_task._start_dev_server = MagicMock()
     app_task._stop_dev_server = MagicMock()
     app_task._app = MagicMock()
@@ -54,7 +54,7 @@ async def test_multiple_file_change(loop, mocker):
     mocked_awatch = mocker.patch('aiohttp_devtools.runserver.watch.awatch')
     mocked_awatch.side_effect = create_awatch_mock({('x', '/path/to/file'), ('x', '/path/to/file2')})
     mock_src_reload = mocker.patch('aiohttp_devtools.runserver.watch.src_reload', return_value=create_future())
-    app_task = AppTask(MagicMock(), loop)
+    app_task = AppTask(MagicMock())
     app_task._start_dev_server = MagicMock()
     app_task._stop_dev_server = MagicMock()
 
@@ -72,7 +72,7 @@ async def test_python_no_server(loop, mocker):
 
     config = MagicMock()
     config.main_port = 8000
-    app_task = AppTask(config, loop)
+    app_task = AppTask(config)
     app_task._start_dev_server = MagicMock()
     app_task._stop_dev_server = MagicMock()
     app = Application()
@@ -98,7 +98,7 @@ async def test_reload_server_running(loop, aiohttp_client, mocker):
     config = MagicMock()
     config.main_port = cli.server.port
 
-    app_task = AppTask(config, loop)
+    app_task = AppTask(config)
     app_task._app = app
     app_task._session = ClientSession()  # match behaviour of _run()
     await app_task._src_reload_when_live(2)
@@ -111,7 +111,7 @@ async def test_livereload_task_single(loop, mocker):
     mocked_awatch.side_effect = create_awatch_mock()
     mock_src_reload = mocker.patch('aiohttp_devtools.runserver.watch.src_reload', return_value=create_future())
 
-    task = LiveReloadTask('x', loop)
+    task = LiveReloadTask('x')
     task._app = MagicMock()
     await task._run()
     mock_src_reload.assert_called_once_with(task._app, '/path/to/file')
@@ -122,7 +122,7 @@ async def test_livereload_task_multiple(loop, mocker):
     mocked_awatch.side_effect = create_awatch_mock({('x', '/path/to/file'), ('x', '/path/to/file2')})
     mock_src_reload = mocker.patch('aiohttp_devtools.runserver.watch.src_reload', return_value=create_future())
 
-    task = LiveReloadTask('x', loop)
+    task = LiveReloadTask('x')
     task._app = MagicMock()
     await task._run()
     mock_src_reload.assert_called_once_with(task._app)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -9,7 +9,7 @@ from aiohttp_devtools.runserver import serve_static
 @pytest.yield_fixture
 def cli(loop, tmpworkdir, aiohttp_client):
     asyncio.set_event_loop(loop)
-    app, _, _, _ = serve_static(static_path=str(tmpworkdir), livereload=False)
+    app, _, _ = serve_static(static_path=str(tmpworkdir), livereload=False)
     yield loop.run_until_complete(aiohttp_client(app))
 
 
@@ -33,7 +33,7 @@ async def test_file_missing(cli):
 
 
 async def test_html_file_livereload(loop, aiohttp_client, tmpworkdir):
-    app, port, _, _ = serve_static(static_path=str(tmpworkdir), livereload=True)
+    app, port, _ = serve_static(static_path=str(tmpworkdir), livereload=True)
     assert port == 8000
     cli = await aiohttp_client(app)
     mktree(tmpworkdir, {
@@ -52,7 +52,7 @@ async def test_html_file_livereload(loop, aiohttp_client, tmpworkdir):
 
 
 async def test_serve_index(loop, aiohttp_client, tmpworkdir):
-    app, port, _, _ = serve_static(static_path=str(tmpworkdir), livereload=False)
+    app, port, _ = serve_static(static_path=str(tmpworkdir), livereload=False)
     assert port == 8000
     cli = await aiohttp_client(app)
     mktree(tmpworkdir, {


### PR DESCRIPTION
This fixes deprecation warnings from using the loop argument. These warnings occur in Python 3.8, and will likely break the project in Python 3.10 if not updated.