### PR TITLE
Fix running in aiohttp 3.8+

### DIFF
--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -21,9 +21,8 @@ def runserver(**config_kwargs):
 
     config = Config(**config_kwargs)
     config.import_app_factory()
-    loop = asyncio.get_event_loop()
 
-    loop.run_until_complete(check_port_open(config.main_port, loop))
+    asyncio.run(check_port_open(config.main_port))
 
     aux_app = create_auxiliary_app(
         static_path=config.static_path_str,
@@ -32,8 +31,7 @@ def runserver(**config_kwargs):
     )
 
     main_manager = AppTask(config)
-    aux_app.on_startup.append(main_manager.start)
-    aux_app.on_shutdown.append(main_manager.close)
+    aux_app.cleanup_ctx.append(main_manager.cleanup_ctx)
 
     if config.static_path:
         static_manager = LiveReloadTask(config.static_path)

--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -70,7 +70,8 @@ def modify_main_app(app, config: Config):
         app['static_root_url'] = MutableValue(static_url)
 
 
-async def check_port_open(port, loop, delay=1):
+async def check_port_open(port: int, delay: int = 1) -> None:
+    loop = asyncio.get_running_loop()
     # the "s = socket.socket; s.bind" approach sometimes says a port is in use when it's not
     # this approach replicates aiohttp so should always give the same answer
     for i in range(5, 0, -1):
@@ -107,7 +108,7 @@ def serve_main_app(config: Config, tty_path: Optional[str]):
         setup_logging(config.verbose)
         app_factory = config.import_app_factory()
         loop = asyncio.get_event_loop()
-        runner = loop.run_until_complete(create_main_app(config, app_factory, loop))
+        runner = loop.run_until_complete(create_main_app(config, app_factory))
         try:
             loop.run_until_complete(start_main_app(runner, config.main_port))
             loop.run_forever()
@@ -118,11 +119,11 @@ def serve_main_app(config: Config, tty_path: Optional[str]):
                 loop.run_until_complete(runner.cleanup())
 
 
-async def create_main_app(config: Config, app_factory, loop):
+async def create_main_app(config: Config, app_factory):
     app = await config.load_app(app_factory)
     modify_main_app(app, config)
 
-    await check_port_open(config.main_port, loop)
+    await check_port_open(config.main_port)
     return web.AppRunner(app, access_log_class=AccessLogger)
 
 

--- a/tests/test_runserver_serve.py
+++ b/tests/test_runserver_serve.py
@@ -21,18 +21,18 @@ non_windows_test = pytest.mark.skipif(
 )
 
 
-async def test_check_port_open(aiohttp_unused_port, loop):
+async def test_check_port_open(aiohttp_unused_port):
     port = aiohttp_unused_port()
-    await check_port_open(port, loop, 0.001)
+    await check_port_open(port, 0.001)
 
 
 @non_windows_test  # FIXME: probably needs some sock options
-async def test_check_port_not_open(aiohttp_unused_port, loop):
+async def test_check_port_not_open(aiohttp_unused_port):
     port = aiohttp_unused_port()
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(('0.0.0.0', port))
         with pytest.raises(AiohttpDevException):
-            await check_port_open(port, loop, 0.001)
+            await check_port_open(port, 0.001)
 
 
 async def test_aux_reload(smart_caplog):

--- a/tests/test_runserver_watch.py
+++ b/tests/test_runserver_watch.py
@@ -44,7 +44,7 @@ async def test_single_file_change(loop, mocker):
     app_task._start_dev_server = MagicMock()
     app_task._stop_dev_server = MagicMock()
     app = MagicMock()
-    await app_task._start(app)
+    await app_task.start(app)
     d = {'static_path': '/path/to/'}
     app_task._app.__getitem__.side_effect = d.__getitem__
     await app_task._task
@@ -63,7 +63,7 @@ async def test_multiple_file_change(loop, mocker):
     app_task._stop_dev_server = MagicMock()
 
     app = MagicMock()
-    await app_task._start(app)
+    await app_task.start(app)
     await app_task._task
     mock_src_reload.assert_called_once_with(app)
     assert app_task._start_dev_server.call_count == 1
@@ -89,7 +89,7 @@ async def test_python_no_server(loop, mocker):
     f.set_result(1)
     mock_ws.send_str = MagicMock(return_value=f)
     app['websockets'] = [(mock_ws, '/')]
-    await app_task._start(app)
+    await app_task.start(app)
     await app_task._task
     assert app_task._app.src_reload.called is False
     assert app_task._start_dev_server.called

--- a/tests/test_runserver_watch.py
+++ b/tests/test_runserver_watch.py
@@ -1,4 +1,5 @@
 import asyncio
+from functools import partial
 from platform import system as get_os_family
 from unittest.mock import MagicMock, call
 
@@ -42,11 +43,12 @@ async def test_single_file_change(loop, mocker):
     app_task = AppTask(MagicMock())
     app_task._start_dev_server = MagicMock()
     app_task._stop_dev_server = MagicMock()
-    app_task._app = MagicMock()
+    app = MagicMock()
+    await app_task._start(app)
     d = {'static_path': '/path/to/'}
     app_task._app.__getitem__.side_effect = d.__getitem__
-    await app_task._run()
-    mock_src_reload.assert_called_once_with(app_task._app, '/path/to/file')
+    await app_task._task
+    mock_src_reload.assert_called_once_with(app, '/path/to/file')
     assert app_task._start_dev_server.call_count == 1
     assert app_task._stop_dev_server.called is False
     await app_task._session.close()
@@ -60,9 +62,10 @@ async def test_multiple_file_change(loop, mocker):
     app_task._start_dev_server = MagicMock()
     app_task._stop_dev_server = MagicMock()
 
-    app_task._app = MagicMock()
-    await app_task._run()
-    mock_src_reload.assert_called_once_with(app_task._app)
+    app = MagicMock()
+    await app_task._start(app)
+    await app_task._task
+    mock_src_reload.assert_called_once_with(app)
     assert app_task._start_dev_server.call_count == 1
     await app_task._session.close()
 
@@ -77,6 +80,7 @@ async def test_python_no_server(loop, mocker):
     app_task = AppTask(config)
     app_task._start_dev_server = MagicMock()
     app_task._stop_dev_server = MagicMock()
+    app_task._run = partial(app_task._run, live_checks=2)
     app = Application()
     app['static_path'] = '/path/to/'
     app.src_reload = MagicMock()
@@ -85,8 +89,8 @@ async def test_python_no_server(loop, mocker):
     f.set_result(1)
     mock_ws.send_str = MagicMock(return_value=f)
     app['websockets'] = [(mock_ws, '/')]
-    app_task._app = app
-    await app_task._run(2)
+    await app_task._start(app)
+    await app_task._task
     assert app_task._app.src_reload.called is False
     assert app_task._start_dev_server.called
     assert app_task._stop_dev_server.called
@@ -115,9 +119,10 @@ async def test_livereload_task_single(loop, mocker):
     mock_src_reload = mocker.patch('aiohttp_devtools.runserver.watch.src_reload', return_value=create_future())
 
     task = LiveReloadTask('x')
-    task._app = MagicMock()
-    await task._run()
-    mock_src_reload.assert_called_once_with(task._app, '/path/to/file')
+    app = MagicMock()
+    await task.start(app)
+    await task._task
+    mock_src_reload.assert_called_once_with(app, '/path/to/file')
 
 
 async def test_livereload_task_multiple(loop, mocker):
@@ -126,9 +131,10 @@ async def test_livereload_task_multiple(loop, mocker):
     mock_src_reload = mocker.patch('aiohttp_devtools.runserver.watch.src_reload', return_value=create_future())
 
     task = LiveReloadTask('x')
-    task._app = MagicMock()
-    await task._run()
-    mock_src_reload.assert_called_once_with(task._app)
+    app = MagicMock()
+    await task.start(app)
+    await task._task
+    mock_src_reload.assert_called_once_with(app)
 
 
 class FakeProcess:


### PR DESCRIPTION
`web.run_app()` now creates a new loop in line with `asyncio.run()`.

There were a couple of bits of the code depending on this implementation detail. Here, I've fixed these dependencies by moving towards high-level APIs.