### PR TITLE
Use new loop (and Runner in 3.11+).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.7', '3.8', '3.9', '3.10']
+        pyver: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.8


### PR DESCRIPTION
Fixes a DeprecationWarning by using `new_event_loop()` instead of `get_event_loop()` on older Python releases, while using `asyncio.Runner()` on Python 3.11+.