### PR TITLE
Rewrite package name

### DIFF
--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -7,6 +7,7 @@ from typing import Awaitable, Callable, Optional, Union
 
 from aiohttp import web
 
+import __main__
 from ..exceptions import AiohttpDevConfigError as AdevConfigError
 from ..logs import rs_dft_logger as logger
 
@@ -131,6 +132,8 @@ class Config:
 
         sys.path.append(str(self.python_path))
         module = import_module(module_path)
+        # Rewrite the package name, so it will appear the same as running the app.
+        __main__.__package__ = module.__package__
 
         logger.debug('successfully loaded "%s" from "%s"', module_path, self.python_path)
 

--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -133,7 +133,8 @@ class Config:
         sys.path.append(str(self.python_path))
         module = import_module(module_path)
         # Rewrite the package name, so it will appear the same as running the app.
-        __main__.__package__ = module.__package__
+        if module.__package__:
+            __main__.__package__ = module.__package__
 
         logger.debug('successfully loaded "%s" from "%s"', module_path, self.python_path)
 


### PR DESCRIPTION
Rewrite the package name, so it appears the same as the app which is being run by devtools.
This can improve the user experience when a tool displays the package name (e.g. As the title in aiohttp-admin).