### PR TITLE
Add no-cache headers to static files

### DIFF
--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -363,4 +363,8 @@ class CustomStaticResource(StaticResource):
         else:
             # Inject CORS headers to allow webfonts to load correctly
             response.headers['Access-Control-Allow-Origin'] = '*'
+
+        # Add no-cache header to avoid browser caching in local development.
+        response.headers["Cache-Control"] = "no-cache"
+
         return response


### PR DESCRIPTION
Add no-cache headers to avoid browser caching of static files during local development.