### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@
 click==8.1.3
 coverage==7.2.7
 grablib==0.8
+watchfiles==0.19.0
+devtools==0.11.0
 pytest==6.2.5
+pytest-asyncio==0.20.3
 pytest-aiohttp==1.0.4
 pytest-cov==4.1.0
 pytest-forked==1.6.0


### PR DESCRIPTION
`pytest` fails to run when starting from a clean `venv` environment. This adds specific packages to `requirements.txt` to fix that.