### PR TITLE
A workaround for issue #565

### DIFF
--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -49,9 +49,6 @@ def runserver(**config_kwargs: Any) -> RunServer:
 
     main_manager = AppTask(config)
     aux_app.cleanup_ctx.append(main_manager.cleanup_ctx)
-    async def do_shutdown(_):
-        main_manager._stop_dev_server()
-    aux_app.on_shutdown.append(do_shutdown)
 
     if config.static_path:
         static_manager = LiveReloadTask(config.static_path)

--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -49,6 +49,9 @@ def runserver(**config_kwargs: Any) -> RunServer:
 
     main_manager = AppTask(config)
     aux_app.cleanup_ctx.append(main_manager.cleanup_ctx)
+    async def do_shutdown(_):
+        main_manager._stop_dev_server()
+    aux_app.on_shutdown.append(do_shutdown)
 
     if config.static_path:
         static_manager = LiveReloadTask(config.static_path)

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -110,7 +110,7 @@ app.router.add_get('/', hello)
     assert isinstance(aux_app, aiohttp.web.Application)
     assert aux_port == 8001
     assert len(aux_app.on_startup) == 1
-    assert len(aux_app.on_shutdown) == 2
+    assert len(aux_app.on_shutdown) == 1
     assert len(aux_app.cleanup_ctx) == 1
 
 

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -83,6 +83,7 @@ def create_app():
     finally:
         for shutdown in aux_app.on_shutdown:
             loop.run_until_complete(shutdown(aux_app))
+        loop.run_until_complete(aux_app.cleanup())
     assert (
         'adev.server.dft INFO: Starting aux server at http://localhost:8001 ◆\n'
         'adev.server.dft INFO: serving static files from ./static_dir/ at http://localhost:8001/static/\n'

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -110,7 +110,7 @@ app.router.add_get('/', hello)
     assert isinstance(aux_app, aiohttp.web.Application)
     assert aux_port == 8001
     assert len(aux_app.on_startup) == 1
-    assert len(aux_app.on_shutdown) == 1
+    assert len(aux_app.on_shutdown) == 2
     assert len(aux_app.cleanup_ctx) == 1
 
 


### PR DESCRIPTION
This is what I was able to come up with to fix #565, that is, it allows the tests to be run multiple times without them leaving processes behind or leaving port 8000 open. However, I'm having trouble keeping track of how the devtools start up and shut down servers, so I'm uncertain if this is a good solution; it may just be a workaround or hack...