### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        pyver: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.8

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ First let's create a clean python environment to work in and install aiohttp-dev
 .. code:: shell
 
     mkdir my_new_app && cd my_new_app
-    virtualenv -p `which python3.7` env
+    virtualenv -p `which python3.8` env
     . env/bin/activate
     pip install aiohttp-devtools create-aio-app
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,4 @@ max-line-length = 120
 max-complexity = 10
 
 [bdist_wheel]
-python-tag = py37.py38.py39.py310
+python-tag = py38.py39.py310.py311

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ setup(
         'Environment :: Console',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'Intended Audience :: System Administrators',
@@ -68,7 +68,6 @@ setup(
         'devtools>=0.6',
         'Pygments>=2.2.0',
         'watchfiles>=0.10',
-        'typing_extensions >= 3.7.4; python_version<"3.8"'
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
@Dreamsorcerer, [here](https://github.com/aio-libs/aiohttp-devtools/pull/549#issuecomment-1519118924) you mentioned that support for 3.7 would be dropped at the next release anyway; it would be useful for my testing in #549 if that could already happen, would that be ok?
