### PR TITLE
Fix requirements-dev.txt on Python 3.7

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,10 @@
 -r requirements.txt
 
-docutils==0.20.1
-flake8==6.0.0
+docutils==0.20.1; python_version >= "3.8"
+docutils==0.17; python_version < "3.8"
+flake8==6.0.0; python_version >= "3.8"
+flake8==5.0.4; python_version < "3.8"
 mypy==1.3.0
-Sphinx==7.0.1
+Sphinx==7.0.1; python_version >= "3.8"
+Sphinx==4.3.2; python_version < "3.8"
 types-pygments==2.15.0.1


### PR DESCRIPTION
The versions of the modules specified in `requirements-dev.txt` aren't compatible with Python 3.7, this update fixes that.