### PR TITLE
Bugfix/import order issue

### DIFF
--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -136,7 +136,7 @@ class Config:
         rel_py_file = self.py_file.relative_to(self.python_path)
         module_path = '.'.join(rel_py_file.with_suffix('').parts)
 
-        sys.path.append(str(self.python_path))
+        sys.path.insert(0, str(self.python_path))
         module = import_module(module_path)
         # Rewrite the package name, so it will appear the same as running the app.
         if module.__package__:

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -7,10 +7,13 @@ import pytest
 from aiohttp import ClientTimeout
 from pytest_toolbox import mktree
 
+from multiprocessing import set_start_method
+
 from aiohttp_devtools.runserver import runserver
 from aiohttp_devtools.runserver.config import Config
 from aiohttp_devtools.runserver.serve import (
     WS, create_auxiliary_app, create_main_app, modify_main_app, src_reload, start_main_app)
+from aiohttp_devtools.runserver.watch import AppTask
 
 from .conftest import SIMPLE_APP, forked
 
@@ -110,6 +113,42 @@ app.router.add_get('/', hello)
     assert len(aux_app.on_startup) == 1
     assert len(aux_app.on_shutdown) == 1
     assert len(aux_app.cleanup_ctx) == 1
+
+
+@forked
+def test_start_runserver_with_multi_app_modules(tmpworkdir, event_loop, capfd):
+    mktree(tmpworkdir, {
+        'app.py': f"""\
+from aiohttp import web
+import sys
+sys.path.insert(0, '{tmpworkdir}/libs/l1')
+
+async def hello(request):
+    return web.Response(text='<h1>hello world</h1>', content_type='text/html')
+
+async def create_app():
+    a = web.Application()
+    a.router.add_get('/', hello)
+    return a
+""",
+        "libs": {
+            "l1": {
+                "__init__.py": "",
+                "app.py": "print('wrong_import')"
+            }
+        }
+    })
+
+    set_start_method('spawn')
+    config = Config(app_path="app.py", root_path=tmpworkdir, main_port=0, app_factory_name="create_app")
+    config.import_app_factory()
+    app_task = AppTask(config)
+    
+    app_task._start_dev_server()
+    app_task._process.join(2)
+
+    captured = capfd.readouterr()
+    assert captured.out == "wrong_import\n"
 
 
 @forked

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -148,7 +148,7 @@ async def create_app():
     app_task._process.join(2)
 
     captured = capfd.readouterr()
-    assert captured.out == "wrong_import\n"
+    assert captured.out == ""
 
 
 @forked


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
If you have a package with same module name, adev tries to import the module from that package rather than honoring the project root.

This PR fixes this issue

## Related issue number  https://github.com/aio-libs/aiohttp-devtools/issues/651

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
