### PR TITLE
Add support for setting binding address

### DIFF
--- a/aiohttp_devtools/cli.py
+++ b/aiohttp_devtools/cli.py
@@ -34,7 +34,7 @@ bind_address_help = "Network address to listen, default localhost. env variable:
 @cli.command()
 @click.argument('path', type=_dir_existing, required=True)
 @click.option('--livereload/--no-livereload', envvar='AIO_LIVERELOAD', default=True, help=livereload_help)
-@click.option('-b', '--bind', "bind_address", envvar="AIO_BIND_ADDRESS", default="localhost", help=bind_address_help)
+@click.option("-b", "--bind", "bind_address", envvar="AIO_BIND_ADDRESS", default="localhost", help=bind_address_help)
 @click.option('-p', '--port', default=8000, type=int)
 @click.option('-v', '--verbose', is_flag=True, help=verbose_help)
 @click.option("--browser-cache/--no-browser-cache", envvar="AIO_BROWSER_CACHE", default=False,
@@ -57,7 +57,7 @@ shutdown_by_url_help = ("The development server will be stopped via a request to
                         "added to the server, instead of via signals (this is the default on Windows). "
                         "env variable: AIO_SHUTDOWN_BY_URL")
 host_help = ('host used when referencing livereload and static files, if blank host is taken from the request header '
-             'with default of bind network address. env variable AIO_HOST')
+             "with default of bind network address. env variable AIO_HOST")
 app_factory_help = ('name of the app factory to create an aiohttp.web.Application with, if missing default app-factory '
                     'names are tried. This can be either a function with signature '
                     '"def create_app(loop): -> Application" or "def create_app(): -> Application" '
@@ -77,7 +77,7 @@ aux_port_help = 'Port to serve auxiliary app (reload and static) on, default por
 @click.option('--livereload/--no-livereload', envvar='AIO_LIVERELOAD', default=None, help=livereload_help)
 @click.option('--host', default=INFER_HOST, help=host_help)
 @click.option('--app-factory', 'app_factory_name', envvar='AIO_APP_FACTORY', help=app_factory_help)
-@click.option('-b', '--bind', "bind_address", envvar="AIO_BIND_ADDRESS", default="localhost", help=bind_address_help)
+@click.option("-b", "--bind", "bind_address", envvar="AIO_BIND_ADDRESS", default="localhost", help=bind_address_help)
 @click.option('-p', '--port', 'main_port', envvar='AIO_PORT', type=click.INT, help=port_help)
 @click.option('--aux-port', envvar='AIO_AUX_PORT', type=click.INT, help=aux_port_help)
 @click.option('-v', '--verbose', is_flag=True, help=verbose_help)

--- a/aiohttp_devtools/cli.py
+++ b/aiohttp_devtools/cli.py
@@ -28,21 +28,23 @@ livereload_help = ('Whether to inject livereload.js into html page footers to au
                    'env variable AIO_LIVERELOAD')
 browser_cache_help = ("When disabled (the default), sends no-cache headers to "
                       "disable browser caching.")
+bind_address_help = "Network address to listen, default localhost. env variable: AIO_BIND_ADDRESS"
 
 
 @cli.command()
 @click.argument('path', type=_dir_existing, required=True)
 @click.option('--livereload/--no-livereload', envvar='AIO_LIVERELOAD', default=True, help=livereload_help)
+@click.option('-b', '--bind', "bind_address", envvar="AIO_BIND_ADDRESS", default="localhost", help=bind_address_help)
 @click.option('-p', '--port', default=8000, type=int)
 @click.option('-v', '--verbose', is_flag=True, help=verbose_help)
 @click.option("--browser-cache/--no-browser-cache", envvar="AIO_BROWSER_CACHE", default=False,
               help=browser_cache_help)
-def serve(path: str, livereload: bool, port: int, verbose: bool, browser_cache: bool) -> None:
+def serve(path: str, livereload: bool, bind_address: str, port: int, verbose: bool, browser_cache: bool) -> None:
     """
     Serve static files from a directory.
     """
     setup_logging(verbose)
-    run_app(**serve_static(static_path=path, livereload=livereload, port=port,
+    run_app(**serve_static(static_path=path, livereload=livereload, bind_address=bind_address, port=port,
                            browser_cache=browser_cache))
 
 
@@ -55,7 +57,7 @@ shutdown_by_url_help = ("The development server will be stopped via a request to
                         "added to the server, instead of via signals (this is the default on Windows). "
                         "env variable: AIO_SHUTDOWN_BY_URL")
 host_help = ('host used when referencing livereload and static files, if blank host is taken from the request header '
-             'with default of localhost. env variable AIO_HOST')
+             'with default of bind network address. env variable AIO_HOST')
 app_factory_help = ('name of the app factory to create an aiohttp.web.Application with, if missing default app-factory '
                     'names are tried. This can be either a function with signature '
                     '"def create_app(loop): -> Application" or "def create_app(): -> Application" '
@@ -75,6 +77,7 @@ aux_port_help = 'Port to serve auxiliary app (reload and static) on, default por
 @click.option('--livereload/--no-livereload', envvar='AIO_LIVERELOAD', default=None, help=livereload_help)
 @click.option('--host', default=INFER_HOST, help=host_help)
 @click.option('--app-factory', 'app_factory_name', envvar='AIO_APP_FACTORY', help=app_factory_help)
+@click.option('-b', '--bind', "bind_address", envvar="AIO_BIND_ADDRESS", default="localhost", help=bind_address_help)
 @click.option('-p', '--port', 'main_port', envvar='AIO_PORT', type=click.INT, help=port_help)
 @click.option('--aux-port', envvar='AIO_AUX_PORT', type=click.INT, help=aux_port_help)
 @click.option('-v', '--verbose', is_flag=True, help=verbose_help)

--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -74,7 +74,14 @@ class Config:
         self.path_prefix = path_prefix
         self.app_factory_name = app_factory_name
         self.infer_host = host == INFER_HOST
-        self.host = bind_address if self.infer_host else host
+
+        if not self.infer_host:
+            self.host = host
+        elif bind_address == "0.0.0.0":
+            self.host = "localhost"
+        else:
+            self.host = bind_address
+
         self.bind_address = bind_address
         self.main_port = main_port
         self.aux_port = aux_port or (main_port + 1)

--- a/aiohttp_devtools/runserver/config.py
+++ b/aiohttp_devtools/runserver/config.py
@@ -42,6 +42,7 @@ class Config:
                  path_prefix: str = "/_devtools",
                  app_factory_name: Optional[str] = None,
                  host: str = INFER_HOST,
+                 bind_address: str = "localhost",
                  main_port: int = 8000,
                  aux_port: Optional[int] = None,
                  browser_cache: bool = False):
@@ -73,7 +74,8 @@ class Config:
         self.path_prefix = path_prefix
         self.app_factory_name = app_factory_name
         self.infer_host = host == INFER_HOST
-        self.host = 'localhost' if self.infer_host else host
+        self.host = bind_address if self.infer_host else host
+        self.bind_address = bind_address
         self.main_port = main_port
         self.aux_port = aux_port or (main_port + 1)
         self.browser_cache = browser_cache
@@ -190,5 +192,5 @@ class Config:
 
     def __str__(self) -> str:
         fields = ("py_file", "static_path", "static_url", "livereload", "shutdown_by_url",
-                  "path_prefix", "app_factory_name", "host", "main_port", "aux_port")
+                  "path_prefix", "app_factory_name", "host", "bind_address", "main_port", "aux_port")
         return 'Config:\n' + '\n'.join('  {0}: {1!r}'.format(f, getattr(self, f)) for f in fields)

--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -138,7 +138,7 @@ async def check_port_open(port: int, host: str = "0.0.0.0", delay: float = 1) ->
         except OSError as e:
             if e.errno != EADDRINUSE:
                 raise
-            dft_logger.warning('%s:%d is already in use, waiting %d...', host, port, i)
+            dft_logger.warning("%s:%d is already in use, waiting %d...", host, port, i)
             await asyncio.sleep(delay)
         else:
             server.close()

--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -32,7 +32,6 @@ except ImportError:
 
 LIVE_RELOAD_HOST_SNIPPET = '\n<script src="http://{}:{}/livereload.js"></script>\n'
 LIVE_RELOAD_LOCAL_SNIPPET = b'\n<script src="/livereload.js"></script>\n'
-HOST = '0.0.0.0'
 
 LAST_RELOAD = web.AppKey("LAST_RELOAD", List[float])
 LIVERELOAD_SCRIPT = web.AppKey("LIVERELOAD_SCRIPT", bytes)
@@ -129,17 +128,17 @@ def modify_main_app(app: web.Application, config: Config) -> None:  # noqa: C901
         _set_static_url(app, static_url)
 
 
-async def check_port_open(port: int, delay: float = 1) -> None:
+async def check_port_open(port: int, host: str = "0.0.0.0", delay: float = 1) -> None:
     loop = asyncio.get_running_loop()
     # the "s = socket.socket; s.bind" approach sometimes says a port is in use when it's not
     # this approach replicates aiohttp so should always give the same answer
     for i in range(5, 0, -1):
         try:
-            server = await loop.create_server(asyncio.Protocol, host=HOST, port=port)
+            server = await loop.create_server(asyncio.Protocol, host=host, port=port)
         except OSError as e:
             if e.errno != EADDRINUSE:
                 raise
-            dft_logger.warning('port %d is already in use, waiting %d...', port, i)
+            dft_logger.warning('%s:%d is already in use, waiting %d...', host, port, i)
             await asyncio.sleep(delay)
         else:
             server.close()
@@ -170,7 +169,7 @@ def serve_main_app(config: Config, tty_path: Optional[str]) -> None:
             with asyncio.Runner() as runner:
                 app_runner = runner.run(create_main_app(config, app_factory))
                 try:
-                    runner.run(start_main_app(app_runner, config.main_port))
+                    runner.run(start_main_app(app_runner, config.bind_address, config.main_port))
                     runner.get_loop().run_forever()
                 except KeyboardInterrupt:
                     pass
@@ -181,7 +180,7 @@ def serve_main_app(config: Config, tty_path: Optional[str]) -> None:
             loop = asyncio.new_event_loop()
             runner = loop.run_until_complete(create_main_app(config, app_factory))
             try:
-                loop.run_until_complete(start_main_app(runner, config.main_port))
+                loop.run_until_complete(start_main_app(runner, config.bind_address, config.main_port))
                 loop.run_forever()
             except KeyboardInterrupt:  # pragma: no cover
                 pass
@@ -194,13 +193,13 @@ async def create_main_app(config: Config, app_factory: AppFactory) -> web.AppRun
     app = await config.load_app(app_factory)
     modify_main_app(app, config)
 
-    await check_port_open(config.main_port)
+    await check_port_open(config.main_port, host=config.bind_address)
     return web.AppRunner(app, access_log_class=AccessLogger, shutdown_timeout=0.1)
 
 
-async def start_main_app(runner: web.AppRunner, port: int) -> None:
+async def start_main_app(runner: web.AppRunner, host: str, port: int) -> None:
     await runner.setup()
-    site = web.TCPSite(runner, host=HOST, port=port)
+    site = web.TCPSite(runner, host=host, port=port)
     await site.start()
 
 

--- a/aiohttp_devtools/runserver/watch.py
+++ b/aiohttp_devtools/runserver/watch.py
@@ -107,7 +107,7 @@ class AppTask(WatchTask):
         assert self._app is not None and self._session is not None
 
         if self._app[WS]:
-            url = 'http://localhost:{.main_port}/?_checking_alive=1'.format(self._config)
+            url = 'http://{0.host}:{0.main_port}/?_checking_alive=1'.format(self._config)
             logger.debug('checking app at "%s" is running before prompting reload...', url)
             for i in range(checks):
                 await asyncio.sleep(0.1)
@@ -141,7 +141,7 @@ class AppTask(WatchTask):
         if self._process.is_alive():
             logger.debug('stopping server process...')
             if self._config.shutdown_by_url:  # Workaround for signals not working on Windows
-                url = "http://localhost:{}{}/shutdown".format(self._config.main_port, self._config.path_prefix)
+                url = "http://{0.host}:{0.main_port}{0.path_prefix}/shutdown".format(self._config)
                 logger.debug("Attempting to stop process via shutdown endpoint {}".format(url))
                 try:
                     with suppress(ClientConnectionError):

--- a/aiohttp_devtools/runserver/watch.py
+++ b/aiohttp_devtools/runserver/watch.py
@@ -107,7 +107,7 @@ class AppTask(WatchTask):
         assert self._app is not None and self._session is not None
 
         if self._app[WS]:
-            url = 'http://{0.host}:{0.main_port}/?_checking_alive=1'.format(self._config)
+            url = "http://{0.host}:{0.main_port}/?_checking_alive=1".format(self._config)
             logger.debug('checking app at "%s" is running before prompting reload...', url)
             for i in range(checks):
                 await asyncio.sleep(0.1)

--- a/tests/test_runserver_config.py
+++ b/tests/test_runserver_config.py
@@ -18,6 +18,9 @@ def test_infer_host(tmpworkdir):
     bind_config = Config(app_path='app.py', bind_address='192.168.1.1')
     assert bind_config.infer_host is True
     assert bind_config.host == "192.168.1.1"
+    bind_any = Config(app_path='app.py', bind_address='0.0.0.0')
+    assert bind_any.infer_host is True
+    assert bind_any.host == "localhost"
 
 
 def test_host_override_addr(tmpworkdir):

--- a/tests/test_runserver_config.py
+++ b/tests/test_runserver_config.py
@@ -13,6 +13,21 @@ async def test_load_simple_app(tmpworkdir):
     Config(app_path='app.py')
 
 
+def test_infer_host(tmpworkdir):
+    mktree(tmpworkdir, SIMPLE_APP)
+    bind_config = Config(app_path='app.py', bind_address='192.168.1.1')
+    assert bind_config.infer_host is True
+    assert bind_config.host == "192.168.1.1"
+
+
+def test_host_override_addr(tmpworkdir):
+    mktree(tmpworkdir, SIMPLE_APP)
+    config = Config(app_path='app.py', host='foobar.com', bind_address='192.168.1.1')
+    assert config.infer_host is False
+    assert config.host == "foobar.com"
+    assert config.bind_address == "192.168.1.1"
+
+
 @forked
 async def test_create_app_wrong_name(tmpworkdir):
     mktree(tmpworkdir, SIMPLE_APP)

--- a/tests/test_runserver_config.py
+++ b/tests/test_runserver_config.py
@@ -15,17 +15,17 @@ async def test_load_simple_app(tmpworkdir):
 
 def test_infer_host(tmpworkdir):
     mktree(tmpworkdir, SIMPLE_APP)
-    bind_config = Config(app_path='app.py', bind_address='192.168.1.1')
+    bind_config = Config(app_path="app.py", bind_address="192.168.1.1")
     assert bind_config.infer_host is True
     assert bind_config.host == "192.168.1.1"
-    bind_any = Config(app_path='app.py', bind_address='0.0.0.0')
+    bind_any = Config(app_path="app.py", bind_address="0.0.0.0")
     assert bind_any.infer_host is True
     assert bind_any.host == "localhost"
 
 
 def test_host_override_addr(tmpworkdir):
     mktree(tmpworkdir, SIMPLE_APP)
-    config = Config(app_path='app.py', host='foobar.com', bind_address='192.168.1.1')
+    config = Config(app_path="app.py", host="foobar.com", bind_address="192.168.1.1")
     assert config.infer_host is False
     assert config.host == "foobar.com"
     assert config.bind_address == "192.168.1.1"

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -58,7 +58,7 @@ def create_app():
     })
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    args = runserver(app_path='app.py', static_path='static_dir', bind_address="0.0.0.0")
+    args = runserver(app_path="app.py", static_path="static_dir", bind_address="0.0.0.0")
     aux_app = args["app"]
     aux_port = args["port"]
     runapp_host = args["host"]

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -61,8 +61,10 @@ def create_app():
     args = runserver(app_path='app.py', static_path='static_dir')
     aux_app = args["app"]
     aux_port = args["port"]
+    runapp_host = args.get("host", "")
     assert isinstance(aux_app, aiohttp.web.Application)
     assert aux_port == 8001
+    assert runapp_host == "localhost"
     for startup in aux_app.on_startup:
         loop.run_until_complete(startup(aux_app))
 
@@ -108,8 +110,10 @@ app.router.add_get('/', hello)
     args = runserver(app_path="app.py", host="foobar.com", main_port=0, aux_port=8001)
     aux_app = args["app"]
     aux_port = args["port"]
+    runapp_host = args.get("host", "")
     assert isinstance(aux_app, aiohttp.web.Application)
     assert aux_port == 8001
+    assert runapp_host == "localhost"
     assert len(aux_app.on_startup) == 1
     assert len(aux_app.on_shutdown) == 1
     assert len(aux_app.cleanup_ctx) == 1

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -58,13 +58,13 @@ def create_app():
     })
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    args = runserver(app_path='app.py', static_path='static_dir')
+    args = runserver(app_path='app.py', static_path='static_dir', bind_address="0.0.0.0")
     aux_app = args["app"]
     aux_port = args["port"]
     runapp_host = args.get("host", "")
     assert isinstance(aux_app, aiohttp.web.Application)
     assert aux_port == 8001
-    assert runapp_host == "localhost"
+    assert runapp_host == "0.0.0.0"
     for startup in aux_app.on_startup:
         loop.run_until_complete(startup(aux_app))
 

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -202,7 +202,7 @@ async def test_serve_main_app(tmpworkdir, mocker):
 
     config = Config(app_path="app.py", main_port=0)
     runner = await create_main_app(config, config.import_app_factory())
-    await start_main_app(runner, config.main_port)
+    await start_main_app(runner, config.bind_address, config.main_port)
 
     mock_modify_main_app.assert_called_with(mock.ANY, config)
 
@@ -226,7 +226,7 @@ app.router.add_get('/', hello)
 
     config = Config(app_path="app.py", main_port=0)
     runner = await create_main_app(config, config.import_app_factory())
-    await start_main_app(runner, config.main_port)
+    await start_main_app(runner, config.bind_address, config.main_port)
 
     mock_modify_main_app.assert_called_with(mock.ANY, config)
 

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -61,7 +61,7 @@ def create_app():
     args = runserver(app_path='app.py', static_path='static_dir', bind_address="0.0.0.0")
     aux_app = args["app"]
     aux_port = args["port"]
-    runapp_host = args.get("host", "")
+    runapp_host = args["host"]
     assert isinstance(aux_app, aiohttp.web.Application)
     assert aux_port == 8001
     assert runapp_host == "0.0.0.0"
@@ -110,7 +110,7 @@ app.router.add_get('/', hello)
     args = runserver(app_path="app.py", host="foobar.com", main_port=0, aux_port=8001)
     aux_app = args["app"]
     aux_port = args["port"]
-    runapp_host = args.get("host", "")
+    runapp_host = args["host"]
     assert isinstance(aux_app, aiohttp.web.Application)
     assert aux_port == 8001
     assert runapp_host == "localhost"

--- a/tests/test_runserver_serve.py
+++ b/tests/test_runserver_serve.py
@@ -21,7 +21,7 @@ from .conftest import SIMPLE_APP, create_future
 
 async def test_check_port_open(unused_tcp_port_factory):
     port = unused_tcp_port_factory()
-    await check_port_open(port, 0.001)
+    await check_port_open(port, delay=0.001)
 
 
 async def test_check_port_not_open(unused_tcp_port_factory):
@@ -29,7 +29,7 @@ async def test_check_port_not_open(unused_tcp_port_factory):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(('0.0.0.0', port))
         with pytest.raises(AiohttpDevException):
-            await check_port_open(port, 0.001)
+            await check_port_open(port, delay=0.001)
 
 
 async def test_aux_reload(smart_caplog):

--- a/tests/test_runserver_watch.py
+++ b/tests/test_runserver_watch.py
@@ -107,6 +107,7 @@ async def test_reload_server_running(aiohttp_client, mocker):
     mock_src_reload = mocker.patch('aiohttp_devtools.runserver.watch.src_reload', return_value=create_future())
     cli = await aiohttp_client(app)
     config = MagicMock()
+    config.host = "localhost"
     config.main_port = cli.server.port
 
     app_task = AppTask(config)


### PR DESCRIPTION
## What do these changes do?

Add a new option `--bind` to set the binding address. Keep `--host` parameter to be used for overriding bind address when referencing static files.

## Are there changes in behavior for the user?

- runserver and serve now only listen to localhost by default.
- host parameter now is infered from bind address.

## Related issue number

Fixes #449 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
