### PR TITLE
Fix test that creates orphan process

### DIFF
--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -120,7 +120,7 @@ app.router.add_get('/', hello)
 
 
 @forked
-def test_start_runserver_with_multi_app_modules(tmpworkdir, capfd):
+async def test_start_runserver_with_multi_app_modules(tmpworkdir, capfd):
     mktree(tmpworkdir, {
         "app.py": f"""\
 from aiohttp import web
@@ -149,10 +149,13 @@ async def create_app():
     app_task = AppTask(config)
 
     app_task._start_dev_server()
-    app_task._process.join(2)
+    try:
+        app_task._process.join(2)
 
-    captured = capfd.readouterr()
-    assert captured.out == ""
+        captured = capfd.readouterr()
+        assert captured.out == ""
+    finally:
+        await app_task._stop_dev_server()
 
 
 @forked


### PR DESCRIPTION
## What do these changes do?

Test `test_start_runserver_with_multi_app_modules` doesn't do cleanup after spawning dev server subprocess. This creates orphan processes after running the test.

It may not be a problem in environments like container or ci action, but I think it would be better to fix this issue. I figured out the issue after seeing several unknown python processes running in background for weeks on my linux box...

## Are there changes in behavior for the user?

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
