### PR TITLE
livereload.js to 4.0.2, ssl support for aux server

### DIFF
--- a/aiohttp_devtools/runserver/main.py
+++ b/aiohttp_devtools/runserver/main.py
@@ -32,7 +32,8 @@ def runserver(**config_kwargs: Any) -> RunServer:
     # force a full reload in sub processes so they load an updated version of code, this must be called only once
     set_start_method('spawn')
     config = Config(**config_kwargs)
-    config.import_module()
+    module = config.import_module()
+    ssl_context = config.get_ssl_context(module)
 
     asyncio.run(check_port_open(config.main_port, host=config.bind_address))
 
@@ -50,7 +51,7 @@ def runserver(**config_kwargs: Any) -> RunServer:
         logger.debug('starting livereload to watch %s', config.static_path_str)
         aux_app.cleanup_ctx.append(static_manager.cleanup_ctx)
 
-    url = 'http://{0.host}:{0.aux_port}'.format(config)
+    url = '{0.protocol}://{0.host}:{0.aux_port}'.format(config)
     logger.info('Starting aux server at %s ◆', url)
 
     if config.static_path:
@@ -58,7 +59,7 @@ def runserver(**config_kwargs: Any) -> RunServer:
         logger.info('serving static files from ./%s/ at %s%s', rel_path, url, config.static_url)
 
     return {"app": aux_app, "host": config.bind_address, "port": config.aux_port,
-            "shutdown_timeout": 0.01, "access_log_class": AuxAccessLogger, "ssl_context": None}
+            "shutdown_timeout": 0.01, "access_log_class": AuxAccessLogger, "ssl_context": ssl_context}
 
 
 def serve_static(*, static_path: str, livereload: bool = True, bind_address: str = "localhost", port: int = 8000,

--- a/aiohttp_devtools/runserver/serve.py
+++ b/aiohttp_devtools/runserver/serve.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     static_root_key = None  # type: ignore[assignment]
 
-LIVE_RELOAD_HOST_SNIPPET = '\n<script src="http://{}:{}/livereload.js"></script>\n'
+LIVE_RELOAD_HOST_SNIPPET = '\n<script src="{}://{}:{}/livereload.js"></script>\n'
 LIVE_RELOAD_LOCAL_SNIPPET = b'\n<script src="/livereload.js"></script>\n'
 
 LAST_RELOAD = web.AppKey("LAST_RELOAD", List[float])
@@ -84,7 +84,7 @@ def modify_main_app(app: web.Application, config: Config) -> None:  # noqa: C901
                     or request.path.startswith("/_debugtoolbar")
                     or "text/html" not in response.content_type):
                 return
-            lr_snippet = LIVE_RELOAD_HOST_SNIPPET.format(get_host(request), config.aux_port)
+            lr_snippet = LIVE_RELOAD_HOST_SNIPPET.format(config.protocol, get_host(request), config.aux_port)
             dft_logger.debug("appending live reload snippet '%s' to body", lr_snippet)
             response.body += lr_snippet.encode()
             response.headers[CONTENT_LENGTH] = str(len(response.body))
@@ -105,7 +105,7 @@ def modify_main_app(app: web.Application, config: Config) -> None:  # noqa: C901
         # we set the app key even in middleware to make the switch to production easier and for backwards compat.
         @web.middleware
         async def static_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
-            static_url = 'http://{}:{}/{}'.format(get_host(request), config.aux_port, static_path)
+            static_url = '{}://{}:{}/{}'.format(config.protocol, get_host(request), config.aux_port, static_path)
             dft_logger.debug('setting app static_root_url to "%s"', static_url)
             _change_static_url(request.app, static_url)
             return await handler(request)
@@ -126,7 +126,7 @@ def modify_main_app(app: web.Application, config: Config) -> None:  # noqa: C901
             config.protocol, config.host, config.main_port, path))
 
     if config.static_path is not None:
-        static_url = 'http://{}:{}/{}'.format(config.host, config.aux_port, static_path)
+        static_url = '{}://{}:{}/{}'.format(config.protocol, config.host, config.aux_port, static_path)
         dft_logger.debug('settings app static_root_url to "%s"', static_url)
         _set_static_url(app, static_url)
 

--- a/grablib.yml
+++ b/grablib.yml
@@ -1,3 +1,3 @@
 download_root: 'aiohttp_devtools/runserver'
 download:
-  'GITHUB/livereload/livereload-js/v2.2.1/dist/livereload.js': '/'
+  'GITHUB/livereload/livereload-js/v4.0.2/dist/livereload.js': '/'

--- a/tests/test_runserver_main.py
+++ b/tests/test_runserver_main.py
@@ -379,7 +379,7 @@ def get_ssl_context():
             text = await r.text()
             print(text)
             assert "<h1>hello world</h1>" in text
-            assert '<script src="http://localhost:8001/livereload.js"></script>' in text
+            assert '<script src="https://localhost:8001/livereload.js"></script>' in text
 
         async with session.get("https://localhost:8000/error", ssl=ssl_context) as r:
             assert r.status == 500
@@ -392,8 +392,8 @@ def get_ssl_context():
             loop.run_until_complete(shutdown(aux_app))
         loop.run_until_complete(aux_app.cleanup())
     assert (
-        "adev.server.dft INFO: Starting aux server at http://localhost:8001 ◆\n"
-        "adev.server.dft INFO: serving static files from ./static_dir/ at http://localhost:8001/static/\n"
+        "adev.server.dft INFO: Starting aux server at https://localhost:8001 ◆\n"
+        "adev.server.dft INFO: serving static files from ./static_dir/ at https://localhost:8001/static/\n"
         "adev.server.dft INFO: Starting dev server at https://localhost:8000 ●\n"
     ) in smart_caplog
     loop.run_until_complete(asyncio.sleep(.25))  # TODO(aiohttp 4): Remove this hack

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -62,7 +62,7 @@ async def test_html_file_livereload(aiohttp_client, tmpworkdir):
     assert r.status == 200
     assert r.headers['content-type'] == 'application/javascript'
     text = await r.text()
-    assert text.startswith('(function e(t,n,r){')
+    assert text.startswith('(function(){function r(e,n,t)')
 
 
 async def test_serve_index(aiohttp_client, tmpworkdir):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
updates livereload.js to 4.0.2, adds ssl support for aux server in runserver mode

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
no

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
